### PR TITLE
#17547: Pricing Rules are not queried correctly after removing 'customer' and adding 'party_name' in Quotation

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -237,6 +237,10 @@ class AccountsController(TransactionBase):
 				document_type = "{} Item".format(self.doctype)
 				parent_dict.update({"document_type": document_type})
 
+                        # To fix the problems cause by renaming 'customer' to 'party_name- in selling docs
+                        if not parent_dict.get("customer") and parent_dict.get("party_name"):
+                                parent_dict.update({"customer": parent_dict.get("party_name")})
+
 			for item in self.get("items"):
 				if item.get("item_code"):
 					args = parent_dict.copy()


### PR DESCRIPTION
- Filling in 'customer' arg field if not already set and if 'party_name' is available
- This will fix the logic during which Pricing Rule is constructing the SQL query to list all Pricing Rules related to an item
- The reason to put it in accounts_controller is:
-# This is the palce when args are made before making call which will end using Pricing Rule logic, which means we don't have to go all over the place to add the proper arg field
-# IMHO, it is clean enough in contrast to the case where that code is added to pricing_rule.py for example, cause doing this exposes Pricing Rule to the knowledge about a field called 'party_name' while a Pricing Rule document doesn't have any

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

